### PR TITLE
keyname to lowercase

### DIFF
--- a/lib/jp/ne/hatena/hadoop/hive/serde/KeyValuePairsDeserializer.java
+++ b/lib/jp/ne/hatena/hadoop/hive/serde/KeyValuePairsDeserializer.java
@@ -99,7 +99,7 @@ public class KeyValuePairsDeserializer implements Deserializer {
             if (!keyValueString.contains(kvSeparator)) continue;
 
             String[] keyValue = keyValueString.split(kvSeparator, 2);
-            Integer colIndex = columnIndexMap.get(keyValue[0]);
+            Integer colIndex = columnIndexMap.get(keyValue[0].toLowerCase());
             if (colIndex != null) {
                 ObjectInspector fieldOI = rowFieldRefs.get(colIndex).getFieldObjectInspector();
                 // FIXME: もっとスマートにやりたい


### PR DESCRIPTION
This patch converts key name in LTSV to lower case.

when we want to insert KV pair as ltsv like "myName:Michel" into table, we have to convert key name to lower case in the serde, because Hive always names column as lowercase like `myname`.
